### PR TITLE
Add deployment tooling for Franklin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+*tfvars*
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+*tfplan*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# franklin-deployment
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+* [Migrations](#migrations)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `raster-foundry`:
+
+```bash
+$ aws configure --profile raster-foundry
+AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+Default region name [None]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+To deploy the API, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done. Be sure to include `GIT_COMMIT` with the first 7 characters of a Git SHA. This value should correspond to a container image tag published to [Quay.io](https://quay.io/azavea/franklin).
+
+```
+$ docker-compose run --rm terraform
+bash-5.0# GIT_COMMIT="..." ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```
+bash-5.0# GIT_COMMIT="..." ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.
+
+## Migrations
+
+- Select the most recent task definition for [FranklinAPIMigrations](https://console.aws.amazon.com/ecs/home?region=us-east-1#/taskDefinitions/FranklinAPIMigrations/status/ACTIVE)
+- Select **Actions** -> **Run Task**
+- Below the warning, click the blue link: "Switch to launch type"
+- Select the following
+  - **Launch type**: `EC2`
+  - **Cluster**: `ecsProductionCluster`
+- Click **Run Task**
+- Monitor the [log output](https://papertrailapp.com/groups/4082183/events?q=franklin-api-migrations) for the newly created task

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+services:
+  terraform:
+    image: quay.io/azavea/terraform:0.12.13
+    volumes:
+      - ./:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-raster-foundry}
+      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - FRANKLIN_DEBUG=1
+      - FRANKLIN_SETTINGS_BUCKET=${FRANKLIN_SETTINGS_BUCKET:-rasterfoundry-production-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${FRANKLIN_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="$(dirname "$0")/../terraform"
+        echo
+        echo "Attempting to deploy application version [${GIT_COMMIT}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${FRANKLIN_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        aws s3 cp "s3://${FRANKLIN_SETTINGS_BUCKET}/terraform/franklin/terraform.tfvars" "${FRANKLIN_SETTINGS_BUCKET}.tfvars"
+
+        case "${1}" in
+        plan)
+            # Clear stale modules & remote state, then re-initialize
+            rm -rf .terraform terraform.tfstate*
+            terraform init \
+                -backend-config="bucket=${FRANKLIN_SETTINGS_BUCKET}" \
+                -backend-config="key=terraform/franklin/state"
+
+            terraform plan \
+                -var="image_tag=${GIT_COMMIT}" \
+                -var-file="${FRANKLIN_SETTINGS_BUCKET}.tfvars" \
+                -out="${FRANKLIN_SETTINGS_BUCKET}.tfplan"
+            ;;
+        apply)
+            terraform apply "${FRANKLIN_SETTINGS_BUCKET}.tfplan"
+            ;;
+        *)
+            echo "ERROR: I don't have support for that Terraform subcommand!"
+            exit 1
+            ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No FRANKLIN_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -1,0 +1,142 @@
+#
+# Security Group Resources
+#
+resource "aws_security_group" "alb" {
+  name   = "sg${var.project}APILoadBalancer"
+  vpc_id = data.terraform_remote_state.core.outputs.vpc_id
+
+  tags = {
+    Name    = "sg${var.project}APILoadBalancer",
+    Project = var.project
+  }
+}
+
+#
+# ALB Resources
+#
+resource "aws_lb" "api" {
+  name            = "alb${var.project}API"
+  security_groups = [aws_security_group.alb.id]
+  subnets         = data.terraform_remote_state.core.outputs.public_subnet_ids
+
+  enable_http2 = true
+
+  tags = {
+    Name    = "alb${var.project}API"
+    Project = var.project
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name = "tg${var.project}API"
+
+  health_check {
+    healthy_threshold   = 3
+    interval            = 30
+    matcher             = 200
+    protocol            = "HTTP"
+    timeout             = 3
+    path                = "/"
+    unhealthy_threshold = 2
+  }
+
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.terraform_remote_state.core.outputs.vpc_id
+
+  tags = {
+    Name    = "tg${var.project}API"
+    Project = var.project
+  }
+}
+
+resource "aws_lb_listener" "api_redirect" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "api" {
+  load_balancer_arn = aws_lb.api.id
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = data.terraform_remote_state.core.outputs.ssl_certificate_arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.api.id
+    type             = "forward"
+  }
+}
+
+#
+# ECS Resources
+#
+resource "aws_ecs_task_definition" "api" {
+  family = "${var.project}API"
+
+  container_definitions = templatefile("${path.module}/task-definitions/api.json.tmpl", {
+    image = "quay.io/azavea/franklin:${var.image_tag}"
+
+    postgres_user     = data.terraform_remote_state.core.outputs.database_username
+    postgres_password = data.terraform_remote_state.core.outputs.database_password
+    postgres_host     = data.terraform_remote_state.core.outputs.database_fqdn
+    postgres_name     = var.rds_database_name
+
+    papertrail_endpoint = data.terraform_remote_state.core.outputs.papertrail_endpoint
+
+    project = var.project
+  })
+}
+
+resource "aws_ecs_task_definition" "api_migrations" {
+  family = "${var.project}APIMigrations"
+
+  container_definitions = templatefile("${path.module}/task-definitions/api_migrations.json.tmpl", {
+    image = "quay.io/azavea/franklin:${var.image_tag}"
+
+    postgres_user     = data.terraform_remote_state.core.outputs.database_username
+    postgres_password = data.terraform_remote_state.core.outputs.database_password
+    postgres_host     = data.terraform_remote_state.core.outputs.database_fqdn
+    postgres_name     = var.rds_database_name
+
+
+    papertrail_endpoint = data.terraform_remote_state.core.outputs.papertrail_endpoint
+
+    project = var.project
+  })
+}
+
+resource "aws_ecs_service" "api" {
+  name                               = "${var.project}API"
+  cluster                            = data.terraform_remote_state.core.outputs.ecs_cluster_name
+  task_definition                    = aws_ecs_task_definition.api.arn
+  desired_count                      = var.desired_count
+  deployment_minimum_healthy_percent = var.deployment_min_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+  iam_role                           = data.terraform_remote_state.core.outputs.ecs_service_role_name
+
+  ordered_placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 9090
+  }
+
+  depends_on = [
+    "aws_lb_listener.api",
+  ]
+}

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -36,7 +36,7 @@ resource "aws_lb_target_group" "api" {
     matcher             = 200
     protocol            = "HTTP"
     timeout             = 3
-    path                = "/"
+    path                = "/open-api/spec.yaml"
     unhealthy_threshold = 2
   }
 

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  version = "~> 2.53.0"
+  region  = var.aws_region
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,14 @@
+#
+# Public DNS resources
+#
+resource "aws_route53_record" "api" {
+  zone_id = data.terraform_remote_state.core.outputs.route53_public_hosted_zone_id
+  name    = "franklin.${data.terraform_remote_state.core.outputs.route53_public_hosted_zone_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.api.dns_name
+    zone_id                = aws_lb.api.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -1,0 +1,47 @@
+#
+# API ALB security group resources
+#
+resource "aws_security_group_rule" "alb_http_ingress" {
+  type             = "ingress"
+  from_port        = 80
+  to_port          = 80
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_https_ingress" {
+  type             = "ingress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_container_instance_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.alb.id
+  source_security_group_id = data.terraform_remote_state.core.outputs.container_instance_security_group_id
+}
+
+#
+# Container instance security group resources
+#
+resource "aws_security_group_rule" "container_instance_alb_ingress" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = data.terraform_remote_state.core.outputs.container_instance_security_group_id
+  source_security_group_id = aws_security_group.alb.id
+}

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -6,7 +6,7 @@ resource "aws_security_group_rule" "alb_http_ingress" {
   from_port        = 80
   to_port          = 80
   protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
+  cidr_blocks      = [var.external_access_cidr_block]
   ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = aws_security_group.alb.id
@@ -17,7 +17,7 @@ resource "aws_security_group_rule" "alb_https_ingress" {
   from_port        = 443
   to_port          = 443
   protocol         = "tcp"
-  cidr_blocks      = ["0.0.0.0/0"]
+  cidr_blocks      = [var.external_access_cidr_block]
   ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = aws_security_group.alb.id

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+
+  config = {
+    region = var.aws_region
+    bucket = "rasterfoundry-${lower(var.environment)}-config-${var.aws_region}"
+    key    = "terraform/core/state"
+  }
+}

--- a/terraform/task-definitions/api.json.tmpl
+++ b/terraform/task-definitions/api.json.tmpl
@@ -1,0 +1,36 @@
+[
+  {
+    "cpu": 512,
+    "essential": true,
+    "image": "${image}",
+    "memory": 1024,
+    "name": "api",
+    "portMappings": [
+      {
+        "containerPort": 9090,
+        "hostPort": 0
+      }
+    ],
+    "command": [
+      "serve",
+      "--db-user",
+      "${postgres_user}",
+      "--db-password",
+      "${postgres_password}",
+      "--db-host",
+      "${postgres_host}",
+      "--db-port",
+      "5432",
+      "--db-name",
+      "${postgres_name}"
+    ],
+    "logConfiguration": {
+      "logDriver": "syslog",
+      "options": {
+        "syslog-address": "${papertrail_endpoint}",
+        "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+        "tag": "franklin-api"
+      }
+    }
+  }
+]

--- a/terraform/task-definitions/api_migrations.json.tmpl
+++ b/terraform/task-definitions/api_migrations.json.tmpl
@@ -1,0 +1,30 @@
+[
+  {
+    "cpu": 512,
+    "essential": true,
+    "image": "${image}",
+    "memory": 1024,
+    "name": "api-migrations",
+    "command": [
+      "migrate",
+      "--db-user",
+      "${postgres_user}",
+      "--db-password",
+      "${postgres_password}",
+      "--db-host",
+      "${postgres_host}",
+      "--db-port",
+      "5432",
+      "--db-name",
+      "${postgres_name}"
+    ],
+    "logConfiguration": {
+      "logDriver": "syslog",
+      "options": {
+        "syslog-address": "${papertrail_endpoint}",
+        "syslog-tls-ca-cert": "/etc/papertrail-bundle.pem",
+        "tag": "franklin-api-migrations"
+      }
+    }
+  }
+]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,10 @@ variable "aws_region" {
   type    = string
 }
 
+variable "external_access_cidr_block" {
+  type = string
+}
+
 variable "rds_database_name" {
   type = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "project" {
+  default = "Franklin"
+  type    = string
+}
+
+variable "environment" {
+  default = "Production"
+  type    = string
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+  type    = string
+}
+
+variable "rds_database_name" {
+  type = string
+}
+
+variable "desired_count" {
+  type = number
+}
+
+variable "deployment_min_percent" {
+  type = number
+}
+
+variable "deployment_max_percent" {
+  type = number
+}
+
+variable "image_tag" {
+  type = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.13"
+}


### PR DESCRIPTION
## Overview

This PR utilizes the remote state outputs from Raster Foundry (ECS cluster, RDS instance) to add an ECS service/ALB for Franklin.

I initialized a new database within the Raster Foundry RDS instance out-of-band:

```bash
$ psql -U raster_foundry -h database.service.rasterfoundry.internal
Password for user raster_foundry:
psql (9.6.11)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

raster_foundry=> create database franklin;
CREATE DATABASE
```

Resolves https://github.com/azavea/raster-foundry-platform/issues/982

## Testing Instructions

Follow the instructions in the README to execute migrations:
```
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.license.VersionPrinter - Flyway Community Edition 6.2.4 by Redgate
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.database.DatabaseFactory - Database: jdbc:postgresql://database.service.rasterfoundry.internal:5432/franklin (PostgreSQL 9.6)
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbValidate - Successfully validated 3 migrations (execution time 00:00.017s)
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory - Creating Schema History table "public"."flyway_schema_history" ...
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbMigrate - Current version of schema "public": << Empty Schema >>
Mar 18 11:54:38 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbMigrate - Migrating schema "public" to version 1 - Add Collection Items
Mar 18 11:54:47 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbMigrate - Migrating schema "public" to version 2 - Add Collections
Mar 18 11:54:47 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbMigrate - Migrating schema "public" to version 3 - add parent collection
Mar 18 11:54:47 52.55.128.27 franklin-api-migrations:  [ioapp-compute-0] INFO org.flywaydb.core.internal.command.DbMigrate - Successfully applied 3 migrations to schema "public" (execution time 00:09.671s)
```

See that the application is serving requests:

```bash
$ http --headers https://franklin.rasterfoundry.com/open-api/spec.yaml
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 6111
Content-Type: text/plain; charset=UTF-8
Date: Wed, 18 Mar 2020 16:33:37 GMT
```