### PR TITLE
Set additional parameters on api service run

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -91,6 +91,7 @@ resource "aws_ecs_task_definition" "api" {
     postgres_password = data.terraform_remote_state.core.outputs.database_password
     postgres_host     = data.terraform_remote_state.core.outputs.database_fqdn
     postgres_name     = var.rds_database_name
+    api_host          = aws_route53_record.api.name
 
     papertrail_endpoint = data.terraform_remote_state.core.outputs.papertrail_endpoint
 

--- a/terraform/task-definitions/api.json.tmpl
+++ b/terraform/task-definitions/api.json.tmpl
@@ -24,7 +24,8 @@
       "--db-name",
       "${postgres_name}",
       "--api-host",
-      "${api_host}"
+      "${api_host}",
+      "--with-transactions"
     ],
     "logConfiguration": {
       "logDriver": "syslog",

--- a/terraform/task-definitions/api.json.tmpl
+++ b/terraform/task-definitions/api.json.tmpl
@@ -25,6 +25,10 @@
       "${postgres_name}",
       "--api-host",
       "${api_host}",
+      "--api-scheme",
+      "https",
+      "--external-port",
+      "443",
       "--with-transactions"
     ],
     "logConfiguration": {

--- a/terraform/task-definitions/api.json.tmpl
+++ b/terraform/task-definitions/api.json.tmpl
@@ -22,7 +22,9 @@
       "--db-port",
       "5432",
       "--db-name",
-      "${postgres_name}"
+      "${postgres_name}",
+      "--api-host",
+      "${api_host}"
     ],
     "logConfiguration": {
       "logDriver": "syslog",


### PR DESCRIPTION
Overview
-----

This PR sets the API host in the command to start the API server to the name of the A record in `dns.tf`. It also sets api-scheme, external-port, and with-transactions.

Notes
-----

Transactions changes here support azavea/raster-foundry-platform#972, other changes are for cosmetics / making the STAC API browseable

Testing
-----

[check it out!](https://franklin.rasterfoundry.com) (links don't say localhost:9090 anymore, transaction endpoints in https://franklin.rasterfoundry.com/open-api/spec.yaml)