### PR TITLE
Open up Franklin server to us east ips

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "alb" {
 #
 resource "aws_lb" "api" {
   name            = "alb${var.project}API"
-  security_groups = [aws_security_group.alb.id]
+  security_groups = "${concat([aws_security_group.alb.id], aws_security_group.franklin_server_alb_whitelist_ec2.*.id)}"
   subnets         = data.terraform_remote_state.core.outputs.public_subnet_ids
 
   enable_http2 = true

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -23,14 +23,45 @@ resource "aws_security_group_rule" "alb_https_ingress" {
   security_group_id = aws_security_group.alb.id
 }
 
-resource "aws_security_group_rule" "alb_container_instance_egress" {
-  type      = "egress"
-  from_port = 0
-  to_port   = 65535
-  protocol  = "tcp"
+# US-East Whitelist
 
-  security_group_id        = aws_security_group.alb.id
-  source_security_group_id = data.terraform_remote_state.core.outputs.container_instance_security_group_id
+data "aws_ip_ranges" "us_east_ec2" {
+  regions  = ["${var.aws_region}"]
+  services = ["ec2"]
+}
+
+locals {
+  ec2_cidr_block_chunks = "${chunklist(data.aws_ip_ranges.us_east_ec2.cidr_blocks, 40)}"
+}
+
+resource "aws_security_group" "franklin_server_alb_whitelist_ec2" {
+  count = "${length(local.ec2_cidr_block_chunks)}"
+
+  vpc_id = data.terraform_remote_state.core.outputs.vpc_id
+
+  egress {
+    from_port       = 0
+    to_port         = 65535
+    protocol        = "tcp"
+    security_groups = [data.terraform_remote_state.core.outputs.container_instance_security_group_id]
+  }
+
+  tags = {
+    Name        = "sgFranklinServerLoadBalancer"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_security_group_rule" "alb_franklin_server_ec2_https_ingress" {
+  count = "${length(local.ec2_cidr_block_chunks)}"
+
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = local.ec2_cidr_block_chunks[count.index]
+  security_group_id = aws_security_group.franklin_server_alb_whitelist_ec2.*.id[count.index]
 }
 
 #


### PR DESCRIPTION
Overview
-----

This PR borrows the strategy taken in Raster Foundry to open up the deployed Franklin server to IPs within the US East 1 EC2 ip range.

Testing
-----

It's currently deployed, look at a lambda execution in the cloud buster step function to see that it succeeded